### PR TITLE
Correction vérification des entrée paybox valident

### DIFF
--- a/modules/RSNImportSources/views/ImportRsnReglementsFromPaybox.php
+++ b/modules/RSNImportSources/views/ImportRsnReglementsFromPaybox.php
@@ -1101,7 +1101,7 @@ class RSNImportSources_ImportRsnReglementsFromPaybox_View extends RSNImportSourc
      * @return boolean - true if the line is a validated receipt.
      */
     function isValidInformationLine($line) {
-        if (sizeof($line) > 0 && is_numeric($line[33])
+        if (sizeof($line) > 0 && is_numeric($line[1])
             && $this->isDate($line[2]) //date
             && $line[19] == 1 //Rank
         ) {
@@ -1275,8 +1275,8 @@ class RSNImportSources_ImportRsnReglementsFromPaybox_View extends RSNImportSourc
             'autorisation'		=> $authorize_payement, 
             'amount'		=> str_to_float($reglement[4]),
             'currency_id'		=> $currencyId,
-            'payment'		=> $reglement[9],// changement de formalisme
-            'paymentstatus'		=> $reglement[7], // regarder le traitement.
+            'payment'		=> $reglement[9],
+            'paymentstatus'		=> $reglement[7],
             'ip'			=> 'xxx.xxx.xxx.xxx',
             'errorcode'		=> $reglement[17],
             'bank'			=> 'xxxx',


### PR DESCRIPTION
On regarde le num de remise au lieu du num d'autorisation.
Car le num d'autorisation peut ne pas être un numéro, mais un mix entre chiffres et lettres